### PR TITLE
Ensures that we are cloning the sticky template

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -73,7 +73,7 @@ form {
 	text-align: center;
 }
 
-.sticky-template {
+.sticky {
 	background-color: yellow;
 	width: 75%;
 	height: 125px;

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
 	<aside id="sticky-generator">
 	<a name="jump"></a> 
 			<h1>Sticky Generator</h1>
-			<div class="sticky-template">
+			<div class="sticky" id="sticky-template">
 				<img src="images/button_plus_blue.png" alt="clone button" id="clone-button">
 				<textarea id="sticky-text"></textarea>
 				<!-- Add ability to change sticky color -->

--- a/js/index.js
+++ b/js/index.js
@@ -25,6 +25,7 @@ $("#howmany").hide();
 $('#clone-button').click(function(){
 	$('<p></p>').appendTo($('#sticky-generator'))
 	var newSticky = $('#sticky-template').clone();
+	newSticky.removeAttr('id');
 	newSticky.appendTo($('#sticky-generator'))
 	newSticky.draggable();
 

--- a/js/index.js
+++ b/js/index.js
@@ -24,7 +24,7 @@ $("#howmany").hide();
 // The sticky becomes draggable and can be moved onto the "brainstorm-board"
 $('#clone-button').click(function(){
 	$('<p></p>').appendTo($('#sticky-generator'))
-	var newSticky = $('.sticky-template').last().clone();
+	var newSticky = $('#sticky-template').clone();
 	newSticky.appendTo($('#sticky-generator'))
 	newSticky.draggable();
 


### PR DESCRIPTION
It seems that `last()` was cloning the last sticky to be cloned. These changes ensure that you are always cloning the "template". I need to do more digging to understand why jQuery draggable doesn't like this.